### PR TITLE
Add an optional command line parameter "exit_method"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # webrecorder
+
 A web server which forwards requests and records/replays responses.
 
     Usage: webrecorder [-options] [url|file]
@@ -21,4 +22,5 @@ A web server which forwards requests and records/replays responses.
       --patch-base-tag           patch base tag so URLs are relative to original host.
       --open-browser             open browser and navigate to requested URL.
       --proxy <host[:port]>      set a HTTP proxy.
+      --exit-method <name>       defines a HTTP method used to exit the application.
       -h, --help                 print this help.

--- a/src/Server.h
+++ b/src/Server.h
@@ -43,7 +43,8 @@ public:
   using HandleRequest = std::function<void(Request)>;
   using HandleError = std::function<void(Request, std::error_code)>;
 
-  Server(HandleRequest handle_request, HandleError handle_error);
+  Server(HandleRequest handle_request, HandleError handle_error,
+    const std::string& exit_method);
   Server(Server&&);
   Server& operator=(Server&&);
   ~Server();

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -133,6 +133,11 @@ bool interpret_commandline(Settings& settings, int argc, const char* argv[]) {
         settings.input_file = settings.output_file =
           utf8_to_path(filename_from_url(settings.url));
     }
+    else if (argument == "--exit-method") {
+      if (++i >= argc)
+        return false;
+      settings.exit_method = argv[i];
+    }
     else {
       return false;
     }

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -40,6 +40,7 @@ struct Settings {
   std::chrono::seconds refresh_timeout{ 1 };
   std::chrono::seconds request_timeout{ 5 };
   bool open_browser{ };
+  std::string exit_method;
 };
 
 bool interpret_commandline(Settings& settings, int argc, const char* argv[]);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -26,7 +26,8 @@ int run(int argc, const char* argv[]) noexcept try {
   using namespace std::placeholders;
   auto server = Server(
     std::bind(&Logic::handle_request, &logic, _1),
-    std::bind(&Logic::handle_error, &logic, _1, _2));
+    std::bind(&Logic::handle_error, &logic, _1, _2),
+    settings.exit_method);
 
   logic.set_start_threads_callback([&]() { server.run_threads(5); });
 


### PR DESCRIPTION
This method can be used to exit the application through TCP (without using signals)